### PR TITLE
Starta- och avslutaknapparna fungerar, simulerar rundomgång för admin samt avslutar event efter 3 rundor

### DIFF
--- a/public/css/eventview.css
+++ b/public/css/eventview.css
@@ -102,3 +102,7 @@
 	border: none;
 	color: white;
 }
+
+#ongoingRound {
+    
+}

--- a/public/css/eventview.css
+++ b/public/css/eventview.css
@@ -91,18 +91,18 @@
 }
 
 #goBackBtn {
-	margin-right: 20px;
-	padding: 12px 24px;
-	position: absolute;
-	right: 0;
-	top: 50%;
-	-ms-transform: translateY(-50%);
-	transform: translateY(-50%);
-	background-color: #A5668B;
-	border: none;
-	color: white;
+    margin-right: 20px;
+    padding: 12px 24px;
+    position: absolute;
+    right: 0;
+    top: 50%;
+    -ms-transform: translateY(-50%);
+    transform: translateY(-50%);
+    background-color: #A5668B;
+    border: none;
+    color: white;
 }
 
-#ongoingRound {
-    
+#eventViewTitle {
+    text-align: center;
 }

--- a/public/css/globalstyle.css
+++ b/public/css/globalstyle.css
@@ -23,10 +23,10 @@ footer {
     color: red;
 }
 
+/* ----- POPUP STYLING ----- */
 .popup {
     background-color: white;
     border: 1px solid black;
-    text-align: center;
     width: 400px;
     top: 50%;
     left: 50%;
@@ -34,6 +34,32 @@ footer {
     display: none;
     position: absolute;
     z-index: 3;
+}
+
+.popupHeader {
+    padding: 16px;
+    background-color: purple;
+    text-align: center;
+    color: white;
+    border-bottom: solid thin black;
+}
+
+.popupBody {
+    padding: 16px;
+    text-align: center;
+    
+}
+
+.closePopup {
+    color: white;
+    float: right;
+    font-size: 24px;
+    font-weight: bold;
+}
+
+.closePopup:hover, .closePopup:focus {
+    text-decoration: none;
+    cursor: pointer;
 }
 
 .overlay {
@@ -46,4 +72,12 @@ footer {
     top: 0;
     left: 0;
     z-index: 2;
+}
+
+
+.smallButton {
+    padding: 12px 24px;
+    background-color: #A5668B;
+    border: none;
+    color: white;
 }

--- a/public/css/globalstyle.css
+++ b/public/css/globalstyle.css
@@ -22,3 +22,28 @@ footer {
     font-weight: bold;
     color: red;
 }
+
+.popup {
+    background-color: white;
+    border: 1px solid black;
+    text-align: center;
+    width: 400px;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    display: none;
+    position: absolute;
+    z-index: 3;
+}
+
+.overlay {
+    background-color: black;
+    opacity: 0.6;
+    width: 100%;
+    height: 100%;
+    display: none;
+    position: fixed;
+    top: 0;
+    left: 0;
+    z-index: 2;
+}

--- a/public/css/index.css
+++ b/public/css/index.css
@@ -33,14 +33,3 @@
 	
 }
 
-.popup {
-    background-color: white;
-    border: 1px solid black;
-    text-align: center;
-    width: 400px;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    display: none;
-    position: absolute;
-}

--- a/public/js/adminstart.js
+++ b/public/js/adminstart.js
@@ -31,11 +31,15 @@ function logout() {
 
 function showCreateEvent() {
     let eventPopup = document.getElementById('createEventPopup');
+    let overlay = document.getElementsByClassName('overlay')[0];
+    overlay.style.display = 'block';
     eventPopup.style.display = "block";
 }
 
 function hideCreateEvent() {
     let eventPopup = document.getElementById('createEventPopup');
+    let overlay = document.getElementsByClassName('overlay')[0];
+    overlay.style.display = 'none';
     eventPopup.style.display = 'none';
 }
 

--- a/public/js/eventview.js
+++ b/public/js/eventview.js
@@ -10,7 +10,7 @@ function initEventView() {
 
     let eventname  = window.location.hash.substring(1);
     let eventPopulation;
-   
+
     socket.emit('getEventData', eventname);
 
     socket.on('eventDataResponse', function(eventData) {
@@ -104,13 +104,20 @@ function moveUser(tableDiv) {
 
 //////////SKRIV FUNKTIONERN UNDER HÄR ///////////////////
 
-let roundNumber = 0;
+/// Stores the roundnumber in localstorage (it exists until we close the browser)
+let roundNumber = parseInt(localStorage.getItem("roundNumber"));
+if (!roundNumber) {
+    roundNumber = 0;
+}
+
 
 async function startRound() {
 
     roundNumber += 1;
+    localStorage.setItem("roundNumber", roundNumber);
     
-    let startRoundPopup = document.getElementById('ongoingRound');
+    let startRoundPopup = document.getElementById('ongoingRoundPopup');
+    let startRoundInfo = document.getElementById('ongoingRoundInfo');
     let overlay = document.getElementsByClassName('overlay')[0];
     overlay.style.display = 'block';
     startRoundPopup.style.display = 'block';
@@ -120,11 +127,46 @@ async function startRound() {
 
     header.appendChild(headerText);
 
-    startRoundPopup.appendChild(header);
+    startRoundInfo.appendChild(header);
 
     await new Promise(r => setTimeout(r, 5000));
 
-    startRoundPopup.removeChild(header);
+    startRoundInfo.removeChild(header);
     overlay.style.display = 'none';
     startRoundPopup.style.display = 'none';
+
+    /// Can't get the title work, it needs to update the round number before the page reload
+    /*
+    let eventViewTitle = document.getElementById('eventViewTitle');
+    eventViewTitle.innerHTML = "Runda #2";
+    */
+
+    location.reload();
+    
+    
+}
+
+
+/// Run in console to reset the round number
+function resetRoundNumber() {
+    roundNumber = 0;
+}
+
+
+function finishEvent() {
+    let exitEventPopup = document.getElementById('exitEventPopup');
+    let overlay = document.getElementsByClassName('overlay')[0];
+    overlay.style.display = 'block';
+    exitEventPopup.style.display = 'block';
+}
+
+function hideExitEventPopup() {
+    let exitEventPopup = document.getElementById('exitEventPopup');
+    let overlay = document.getElementsByClassName('overlay')[0];
+    overlay.style.display = 'none';
+    exitEventPopup.style.display = 'none';
+}
+
+function exitEvent() {
+    window.location.href = "http://localhost:3000/admin/start#admin";
 }

--- a/public/js/eventview.js
+++ b/public/js/eventview.js
@@ -103,3 +103,28 @@ function moveUser(tableDiv) {
 }
 
 //////////SKRIV FUNKTIONERN UNDER HÄR ///////////////////
+
+let roundNumber = 0;
+
+async function startRound() {
+
+    roundNumber += 1;
+    
+    let startRoundPopup = document.getElementById('ongoingRound');
+    let overlay = document.getElementsByClassName('overlay')[0];
+    overlay.style.display = 'block';
+    startRoundPopup.style.display = 'block';
+
+    let header = document.createElement('h2');
+    let headerText = document.createTextNode('Runda #' + roundNumber + ' pågår...');
+
+    header.appendChild(headerText);
+
+    startRoundPopup.appendChild(header);
+
+    await new Promise(r => setTimeout(r, 5000));
+
+    startRoundPopup.removeChild(header);
+    overlay.style.display = 'none';
+    startRoundPopup.style.display = 'none';
+}

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -22,6 +22,8 @@ function loginUser() {
 
 function showAdminLogin() {
     let popup = document.getElementById('adminLoginPopup');
+    let overlay = document.getElementsByClassName('overlay')[0];
+    overlay.style.display = 'block';
     popup.style.display = "block";
 }
 
@@ -32,6 +34,8 @@ function closeAdminLogin() {
     if (errorMsg.childNodes[0]) {
 	errorMsg.removeChild(errorMsg.childNodes[0]);
     }
+    let overlay = document.getElementsByClassName('overlay')[0];
+    overlay.style.display = 'none';
 }
 
 function loginAdmin() {

--- a/views/admin/adminstart.html
+++ b/views/admin/adminstart.html
@@ -9,6 +9,7 @@
     <script src="/js/global.js" defer></script>
     <script src="/js/adminstart.js" defer></script>
   </head>
+  <div class="overlay"></div>
   <body>
     <header>
       <div class="topbar">
@@ -22,15 +23,18 @@
 	<input type="button" value="Skapa nytt" id="createNewBtn" onclick="showCreateEvent()">
       </div>
       <div class="popup" id="createEventPopup">
-	<h2>Skapa event</h2>
-	<label for="eventName">Eventets namn</label><br>
-	<input type="text" id="eventName"><br>
-	<label for="eventPopulation">Antal deltagare</label><br>
-	<input type="number" id="eventPopulation">
-	<p class="errorMessage" id="createEventError"></p>
-	<button class="button" id="createEventButton" onclick="createNewEvent()">Skapa event</button><br>
-	<button class="button" id="clodeEventButton" onclick="hideCreateEvent()">Stäng</button>
-	
+	<div class="popupHeader">
+	  <span class="closePopup" onclick="hideCreateEvent()">&times</span>
+	  <h2>Skapa event</h2>
+	</div>
+	<div class="popupBody">
+	  <label for="eventName">Eventets namn</label><br>
+	  <input type="text" id="eventName"><br>
+	  <label for="eventPopulation">Antal deltagare</label><br>
+	  <input type="number" id="eventPopulation">
+	  <p class="errorMessage" id="createEventError"></p>
+	  <button class="smallButton" id="createEventButton" onclick="createNewEvent()">Skapa event</button><br>
+	</div>
       </div>
       <div id="currentEvents">
 	<h2>Pågående events</h2>

--- a/views/admin/eventview.html
+++ b/views/admin/eventview.html
@@ -7,7 +7,9 @@
     <script src="/js/eventview.js" defer></script>
     <script src="/js/global.js" defer></script>
   </head>
+  <div class="overlay"></div>
   <body onload="initEventView()">
+    <div class="overlay"></div>
     <header>
       <div class="topbar">
 	<img src="/img/aubergine_logo.png" width="260">
@@ -19,14 +21,19 @@
 	<div id="tableGrid">
 	</div>
 	<div id="buttons">
-	  <input type="button" value="Starta" id="startButton" onclick="start()">
+	  <input type="button" value="Starta" id="startButton" onclick="startRound()">
 	  <input type="button" value="Matcha" id="macthButton" onclick="match()">
-	  <input type="button" value="Avsluta runda" id="finishButton" onclick="finish()">
+	  <input type="button" value="Avsluta runda" id="finishButton" onclick="finishRound()">
 	</div>
       </div>
       <div id="sidebar">
-
+	
       </div>
+
+      <div class="popup" id="ongoingRound">
+	
+      </div>
+      
     </main>
     <footer>
     </footer>

--- a/views/admin/eventview.html
+++ b/views/admin/eventview.html
@@ -23,7 +23,7 @@
 	<div id="buttons">
 	  <input type="button" value="Starta" id="startButton" onclick="startRound()">
 	  <input type="button" value="Matcha" id="macthButton" onclick="match()">
-	  <input type="button" value="Avsluta runda" id="finishButton" onclick="finishEvent()">
+	  <input type="button" value="Avsluta runda" id="finishButton" onclick="showExitEvent()">
 	</div>
       </div>
       <div id="sidebar">
@@ -41,6 +41,12 @@
 	<div class="popupBody">
 	  <input class="smallButton" id="yesBtn" type="button" value="Ja" onclick="exitEvent()">
 	  <input class="smallButton" id="noBtn" type="button" value="Nej" onclick="hideExitEventPopup()">
+	</div>
+      </div>
+
+      <div class="popup" id="finishedEventPopup">
+	<div class="popupBody">
+	  <h2>Eventet är nu klart, du omdirigeras till arrangörsstartsidan</h2>
 	</div>
       </div>
       

--- a/views/admin/eventview.html
+++ b/views/admin/eventview.html
@@ -23,15 +23,25 @@
 	<div id="buttons">
 	  <input type="button" value="Starta" id="startButton" onclick="startRound()">
 	  <input type="button" value="Matcha" id="macthButton" onclick="match()">
-	  <input type="button" value="Avsluta runda" id="finishButton" onclick="finishRound()">
+	  <input type="button" value="Avsluta runda" id="finishButton" onclick="finishEvent()">
 	</div>
       </div>
       <div id="sidebar">
 	
       </div>
 
-      <div class="popup" id="ongoingRound">
-	
+      <div class="popup" id="ongoingRoundPopup">
+	<div class="popupBody" id="ongoingRoundInfo"></div>
+      </div>
+
+      <div class="popup" id="exitEventPopup">
+	<div class="popupHeader">
+	  <h2>Vill du avsluta eventet?</h2>
+	</div>
+	<div class="popupBody">
+	  <input class="smallButton" id="yesBtn" type="button" value="Ja" onclick="exitEvent()">
+	  <input class="smallButton" id="noBtn" type="button" value="Nej" onclick="hideExitEventPopup()">
+	</div>
       </div>
       
     </main>

--- a/views/index.html
+++ b/views/index.html
@@ -16,7 +16,7 @@
       </div>
     </header>
     <main>
-      <div id="overlay"></div>
+      
 
       <section id="userLogin">
 	

--- a/views/index.html
+++ b/views/index.html
@@ -8,6 +8,7 @@
     <script src="/js/global.js" defer></script>
     <script src="/js/index.js" defer></script>
   </head>
+  <div class="overlay"></div>
   <body>
     <header>
       <div class="topbar">
@@ -28,14 +29,18 @@
       </section>
 
       <div class="popup" id="adminLoginPopup">
-	<h2>Logga in som administratör</h2>
-	<label for="adminUsername">Användarnamn</label><br>
-	<input type="text" id="adminUsername" required><br>
-	<label for="adminPassword">Lösenord</label><br>
-	<input type="password" id="adminPassword" required><br>
-	<p class="errorMessage" id="adminError"></p>
-	<button class="button" id="loginBtn" type="submit" onclick="loginAdmin()">Logga in</button><br>
-	<button class="button" id="closeBtn" type="button" onclick="closeAdminLogin()">Stäng</button>
+	<div class="popupHeader">
+	  <span class="closePopup" onclick="closeAdminLogin()">&times</span>
+	  <h2>Logga in som administratör</h2>
+	</div>
+	<div class="popupBody">
+	  <label for="adminUsername">Användarnamn</label><br>
+	  <input type="text" id="adminUsername" required><br>
+	  <label for="adminPassword">Lösenord</label><br>
+	  <input type="password" id="adminPassword" required><br>
+	  <p class="errorMessage" id="adminError"></p>
+	  <button class="smallButton" id="loginBtn" type="submit" onclick="loginAdmin()">Logga in</button><br>
+	</div>
       </div>
    
     </main>


### PR DESCRIPTION
Task:
Gör så att arrangörens knappar som styr eventet funkar som dom ska, "gå vidare" "stoppa event" osv. (3h)

När man har skapat ett event så kan man starta rundomgången med ett knapptryck på "Starta", då poppar det upp en ruta som ska simulera en rundomgång (är nu inställd på 5 sekunder). Efter den rutan så laddas sidan om så alla deltagare hamnar i 'sidebaren' igen.

Man kan även trycka på "Avsluta", då får man en popup som ställer frågan om man vill avsluta eventet, om "Ja" så omdirigeras man till arrangörens startsida, om "Nej", så stängs popupen ned.

Efter 3 rundomgångar så avslutas eventet automatiskt och talar om detta för arrangören med ytterligare en popup (:D) som är uppe i 2 sekunder och sedan omdirigeras man till arrangörens startsida.