### PR TITLE
The sidebar now update the profiles from the database.

### DIFF
--- a/app.js
+++ b/app.js
@@ -173,6 +173,16 @@ if (err) {
   });
 }
 
+User.prototype.getUsers = function () {
+    let users = fs.readFileSync('database/users/users.json', function(error) {
+        if (error) {
+            throw error;
+        }
+    });
+
+    return JSON.parse(users);
+}
+
 
 function getUserCodes() {
     let array = fs.readFileSync('database/users/allActiveCodes.json', 'utf8', function(error) {
@@ -220,7 +230,13 @@ io.on('connection', function(socket) {
     });
 
     socket.on('addProfile', function (newProfile) {
-    user.addProfile(newProfile);
+        user.addProfile(newProfile);
+        io.sockets.emit('newUserCreated', newProfile);
+    });
+
+    socket.on('getUsers', function() {
+        let users = user.getUsers();
+        socket.emit('profileDataResponse', users);
     });
 });
 

--- a/public/img/awaiting.jpg:Zone.Identifier
+++ b/public/img/awaiting.jpg:Zone.Identifier
@@ -1,4 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-ReferrerUrl=https://www.google.com/
-HostUrl=https://www.cringlefordpc.org.uk/wp/wp-content/uploads/2017/02/awaiting.jpg


### PR DESCRIPTION
När en profil skapas så skickas även en emit till eventview som gör att 'sidebaren' läser in den informationen automatiskt och ändrar användarkoden till de uppgifter som finns lagrat för den användaren i databasen (just nu namn och ålder).

Har även ändrat om lite i koden när vi initierar våra användare så att vi läser direkt från databasen.
Ifall vi läser in en användare som inte har skapat sin profil så kommer det bara stå deras användarkod och ifall de har gjort sin profil så använder vi den informationen.

Testa gärna att starta ett nytt event och öppna en ny flik/fönster och skapa en profil med någon av de användarkoder som finns på eventvyn. När profilen är skapad så bör ni se att användarkoden i eventvyn har ändrats till det namn och ålder ni angav. Kolla också att användaren finns kvar om ni 'refreshar' sidan.

Just nu är länken från profilskapandet utkommenterad, men vi får fixa det när vi har gjort klart nästa steg.